### PR TITLE
fix: workaround npm bug

### DIFF
--- a/oddish.ts
+++ b/oddish.ts
@@ -41,6 +41,7 @@ async function triggerPipeline(data: {
     const body = new FormData();
     if (GITLAB_STATIC_PIPELINE_TOKEN) {
       body.append("token", GITLAB_STATIC_PIPELINE_TOKEN);
+    } else {
       core.warning('MISSING gitlab-pipeline-url')
     }
     body.append("ref", "master");

--- a/oddish.ts
+++ b/oddish.ts
@@ -74,12 +74,7 @@ async function uploadTarToS3(localFile: string) {
   const BUCKET = core.getInput("s3-bucket", { required: false, trimWhitespace: true });
   const BUCKET_KEY_PREFIX = core.getInput("s3-bucket-key-prefix", { required: false }) || "";
 
-  if (typeof BUCKET != "string") return;
-
-  if (!BUCKET) {
-    core.setFailed("s3-bucket is empty");
-    return;
-  }
+  if (typeof BUCKET != "string" || !BUCKET) return;
 
   const s3 = new AWS.S3({
     signatureVersion: "v4",

--- a/oddish.ts
+++ b/oddish.ts
@@ -110,12 +110,14 @@ async function createArtifacts(workingDirectory: string) {
       );
 
       for (let file of packDetails) {
-        const localFile = workingDirectory + "/" + file.filename.replace('@', ' ').replace('/','-');
+        // This is workaround of a NPM bug which returns wrong filename
+        const filename = file.filename.replace(/^@/, '').replace(/\//, '-')
+        const localFile = workingDirectory + "/" + filename;
 
         // Assuming the current working directory is /home/user/files/plz-upload
         const artifactClient = artifact.create();
 
-        await artifactClient.uploadArtifact(file.filename, [localFile], workingDirectory, {
+        await artifactClient.uploadArtifact(filename, [localFile], workingDirectory, {
           continueOnError: false,
         });
 

--- a/oddish.ts
+++ b/oddish.ts
@@ -110,7 +110,7 @@ async function createArtifacts(workingDirectory: string) {
       );
 
       for (let file of packDetails) {
-        const localFile = workingDirectory + "/" + file.filename;
+        const localFile = workingDirectory + "/" + file.filename.replace('@', ' ').replace('/','-');
 
         // Assuming the current working directory is /home/user/files/plz-upload
         const artifactClient = artifact.create();


### PR DESCRIPTION
# What?
Replace filename @ and /
The same replace that `npm` did (https://github.com/npm/cli/blob/latest/lib/commands/pack.js#L44)

# Why? 
https://github.com/npm/cli/issues/3405