### PR TITLE
feat: add branch-to-next param

### DIFF
--- a/oddish.ts
+++ b/oddish.ts
@@ -419,6 +419,9 @@ const run = async () => {
       } else {
         npmTag = "next";
       }
+
+    } else if (core.getInput("branch-to-next") === branch) {
+      npmTag = "next";
     } else {
       core.info(
         `! canceling automatic npm publish. It can only be made in main/master branches or tags`


### PR DESCRIPTION
# What?
It would enable the `6.x.x` branch-version to publish the package `decentraland-ecs@next` 